### PR TITLE
Change Opportunity to Account in newInstance

### DIFF
--- a/fflib-sample-code/src/classes/AccountsSelector.cls
+++ b/fflib-sample-code/src/classes/AccountsSelector.cls
@@ -32,7 +32,7 @@ public with sharing class AccountsSelector extends fflib_SObjectSelector
 {
 	public static IAccountsSelector newInstance()
 	{
-		return (IAccountsSelector) Application.Selector.newInstance(Opportunity.SObjectType);
+		return (IAccountsSelector) Application.Selector.newInstance(Account.SObjectType);
 	}
 	
 	public List<Schema.SObjectField> getSObjectFieldList()


### PR DESCRIPTION
I'm pretty sure this is a bug in the sample code, but the newInstance method wasn't being called from anywhere.