### PR TITLE
Update package.xml

### DIFF
--- a/fflib-sample-code/src/package.xml
+++ b/fflib-sample-code/src/package.xml
@@ -25,9 +25,11 @@
 		<members>OpportunitiesService</members>
 		<members>OpportunitiesServiceImpl</members>
 		<members>OpportunitiesServiceTest</members>
+		<members>OpportunitiesServiceTestIntegration</members>
 		<members>OpportunitiesTest</members>
 		<members>OpportunityApplyDiscountController</members>
 		<members>OpportunityApplyDiscountControllerTest</members>
+		<members>OpportunityApplyDiscountControllerTestI</members>
 		<members>OpportunityConsoleController</members>
 		<members>OpportunityCreateInvoiceController</members>
 		<members>OpportunityInvoicingController</members>


### PR DESCRIPTION
When deploying the same application, the follwing errors are thrown.

Failures:
classes/OpportunitiesServiceTestIntegration.cls(OpportunitiesServiceTestIntegration):Not in package.xml
classes/OpportunityApplyDiscountControllerTestI.cls(OpportunityApplyDiscountControllerTestI):Not in package.xml